### PR TITLE
Fix highlight of escaped string chars into lambda functions

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -23,6 +23,8 @@ syn match elmBraces  "[()[\]{}]"
 
 " Functions
 syn match elmTupleFunction "\((,\+)\)"
+syn match elmLambdaFunc /\\.*->/hs=s+1,he=e-1
+
 
 " Comments
 syn keyword elmTodo TODO FIXME XXX contained
@@ -75,6 +77,7 @@ hi def link elmAlias Delimiter
 hi def link elmOperator Operator
 hi def link elmType Identifier
 hi def link elmNumberType Identifier
+hi def link elmLambdaFunc Function
 
 syn sync minlines=500
 


### PR DESCRIPTION
This should highlight the lambda function attributes. Since the last syntax definition have highest prior the `elmLamdaFunction` should overwrite the `elmStringEscape` highlight.

#1 Should be close by this PR.
